### PR TITLE
Fix Autoirri_nFKcrit parameter description encoding

### DIFF
--- a/Components/Soil/URootedSoil.pas
+++ b/Components/Soil/URootedSoil.pas
@@ -233,7 +233,7 @@ begin
   ParCreate('CompFactor', '[-]', 0.5, CompFactor, 'root competition factor, 1 leads to proportional potential water uptake by relative root length, 0.5 accounts for root competition');
   ParCreate('nFKcrit','[-]', 0.5, nFKcrit, 'relative soil water content where root water uptake reduces if nFKcrit option is choosen');
   ParCreate('IrriAmount','[mm]',10,IrriAmount, 'Amount of automated irrigation per irrigation');
-  ParCreate('Autoirri_nFKcrit', '[%]', 60, Autoirri_nFKcrit, 'Prozent nFK ab der bew�ssert wird, wenn AutoirriMeth auf amProznFKWe steht');
+  ParCreate('Autoirri_nFKcrit', '[%]', 60, Autoirri_nFKcrit, 'Prozent nFK ab der bewässert wird, wenn AutoirriMeth auf amProznFKWe steht');
   ParCreate('r_root', '[cm]', 0.01, r_root, 'root radius [cm]');
 
 


### PR DESCRIPTION
## Summary
- fix misencoded character in Autoirri_nFKcrit parameter description so "bewässert" displays correctly

## Testing
- `fpc Components/Soil/URootedSoil.pas` *(fails: command not found)*
- `apt-get install -y fp-compiler` *(fails: package not found due to missing repository information)*
- `pre-commit run --files Components/Soil/URootedSoil.pas` *(fails: command not found)*
- `pip install pre-commit` *(fails: proxy blocks connection)*

------
https://chatgpt.com/codex/tasks/task_e_688db84705348325a60fbd340b72b63e