### PR TITLE
Fix W usage in log growth rate calculation

### DIFF
--- a/Tools/MMtoD/UmainTest.pas
+++ b/Tools/MMtoD/UmainTest.pas
@@ -90,8 +90,8 @@ procedure TLogGrowth.CalcRates;
 
 begin
 
-   dW_dt.v :=  mue.v*S.v*W;
-   RGR.v :=  dW_dt.v/W;
+   dW_dt.v :=  mue.v*S.v*W.v;
+   RGR.v :=  dW_dt.v/W.v;
 
 
    S.c :=  -dW_dt;


### PR DESCRIPTION
## Summary
- ensure weight calculations use the state's value `W.v` when computing `dW_dt` and `RGR`

## Testing
- `fpc Tools/MMtoD/UmainTest.pas` *(missing: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688db7fbd35c8325a9c959d830eaa8e8