### PR TITLE
Instantiate missing parameters in 2D nitrate submodel

### DIFF
--- a/Components/Soil/U2DSoilBaseClasses.pas
+++ b/Components/Soil/U2DSoilBaseClasses.pas
@@ -686,6 +686,8 @@ begin
   ParCreate('ContRad', '[cm]', 10, ContRad, 'radius of the container in container mode');
   // Create and initialize TState
 
+  VarCreate('dx', '[cm]', 0, false, dx);
+  VarCreate('dy', '[cm]', 0, false, dy);
   VarCreate('RLD_mean', '[cm/cm^3]', 0, false, RLD_mean);
   VarCreate('AreaMiddle', '[cm2]', 0, false, AreaMiddle);
   VarCreate('num_roots', '[-]', 0, false, num_roots);
@@ -694,6 +696,7 @@ begin
   VarCreate('theta', '[cm3/cm3]', 0, false, theta, 'actual volumetric water content');
   VarCreate('errorReg', '[%]', 0, false, errorReg);
   VarCreate('int_dt', '[d]', 0, false, int_dt);
+  VarCreate('wl_ha', '[cm/ha]', 0, false, wl_ha);
 
   VarCreate('dim_xMiddle', '[d]', 0, false, dim_xMiddle);
   VarCreate('dim_yMiddle', '[d]', 0, false, dim_yMiddle);

--- a/Components/Soil/USubmodDiff2DRootsNitrate.pas
+++ b/Components/Soil/USubmodDiff2DRootsNitrate.pas
@@ -272,11 +272,24 @@ begin
   ParCreate('Ar', '[kg N/ha*d]', 0, Ar);
   ParCreate('Km', '[mikromol/l]', 0, Km);
   ParCreate('Clmin', '[mikromol/l]', 0, Clmin, 'minimum Nitrate concentration');
+  ParCreate('dim_x', '[n]', 500, dim_x);
+  ParCreate('dim_y', '[n]', 500, dim_y);
+  ParCreate('ini_dt', '[s]', 3600, ini_dt);
+  ParCreate('ContRad', '[cm]', 10, ContRad, 'radius of the container in container mode');
+  // Erzeugen und initialisieren von TVar
+  VarCreate('Distance', '[cm]', 0, false, Distance);
+  VarCreate('dx', '[cm]', 0, true, dx);
+  VarCreate('dy', '[cm]', 0, true, dy);
+  VarCreate('Flaeche', '[cm2]', 0, false, Flaeche);
   VarCreate('ActArFromConc', '[kg N/(ha*d)]', 0, false, ActArFromConc);
   VarCreate('int_dt', '[s]', 0, false, int_dt);
   VarCreate('c_av', '[mol/cm3]', 0, false, c_av);
   VarCreate('Imaxa', '[mol/cm/s]', 0, false, Imax);
+  VarCreate('wl', '[cm/(Flaeche*Tiefe)]', 0, false, wl);
+  VarCreate('wl_ha', '[cm/ha]', 0, false, wl_ha);
   VarCreate('ActAr', '[kg N/(ha*d)]', 0, false, ActAr);
+  VarCreate('dim_xMiddle', '[-]', 0, false, dim_xMiddle);
+  VarCreate('dim_yMiddle', '[-]', 0, false, dim_yMiddle);
   // Erzeugen und initialisieren von TState
   StateCreate('Bilanz_f', '[kg N/ha]', 0, false, Bilanz_f);
   // Erzeugen und initialisieren von TOption

--- a/Components/Soil/USubmodRoot2DDiffNitrate.pas
+++ b/Components/Soil/USubmodRoot2DDiffNitrate.pas
@@ -320,6 +320,59 @@ begin
   NitrateUptakeFunction.OptionList.add('ZeroSink');
   NitrateUptakeFunction.OptionList.add('ConstInflux');
   NitrateUptakeFunction.OptionList.add('MM');
+
+  OptCreate('ContGrowth', 'no', ContGrowth);
+  ContGrowth.OptionList.add('yes');
+  ContGrowth.OptionList.add('no');
+
+  OptCreate('ShowConc', 'True', ShowConc);
+  ShowConc.OptionList.add('true');
+  ShowConc.OptionList.add('false');
+
+  OptCreate('CalcModeSteadyState', 'withoutMargin', CalcModeSteadyState);
+  CalcModeSteadyState.OptionList.add('withMargin');
+  CalcModeSteadyState.OptionList.add('withoutMargin');
+
+  OptCreate('SteadyState', 'no', SteadyState);
+  SteadyState.OptionList.add('yes');
+  SteadyState.OptionList.add('no');
+
+  OptCreate('RootDistribution', 'Random', RootDistribution);
+  RootDistribution.OptionList.add('Random');
+  RootDistribution.OptionList.add('Regular');
+  RootDistribution.OptionList.add('FromSource');
+
+  OptCreate('DelMarginRoots', 'no', DelMarginRoots);
+  DelMarginRoots.OptionList.add('yes');
+  DelMarginRoots.OptionList.add('no');
+
+  OptCreate('writeConcField', 'no', writeConcField);
+  writeConcField.OptionList.add('no');
+  writeConcField.OptionList.add('yes');
+
+  OptCreate('writeSinkCellFile', 'no', writeSinkCellFile);
+  writeSinkCellFile.OptionList.add('no');
+  writeSinkCellFile.OptionList.add('yes');
+
+  OptCreate('OutputSink', 'no', OutputSink);
+  OutputSink.OptionList.add('no');
+  OutputSink.OptionList.add('yes');
+
+  OptCreate('ConcFieldDataFile',
+    'Q:\Kohl\DiffModell\IniFilesAusgaben\concField.csv', ConcFieldDataFile);
+  ConcFieldDataFile.OptionList.add
+    ('Q:\Kohl\DiffModell\IniFilesAusgaben\concField.csv');
+
+  OptCreate('SinkCellFileFile',
+    'Q:\Kohl\DiffModell\IniFilesAusgaben\SinkFile.csv', SinkCellFileFile);
+  SinkCellFileFile.OptionList.add
+    ('Q:\Kohl\DiffModell\IniFilesAusgaben\SinkFile.csv');
+
+  OptCreate('RootSinkOutpDataFile',
+    'Q:\Kohl\DiffModell\IniFilesAusgaben\in.dat', RootSinkOutpDataFile);
+  RootSinkOutpDataFile.OptionList.add
+    ('Q:\Kohl\DiffModell\IniFilesAusgaben\in.dat');
+
   OptCreate('OutputXY', 'no', OutputXY);
   OutputXY.OptionList.add('no');
   OutputXY.OptionList.add('yes');


### PR DESCRIPTION
## Summary
- instantiate the remaining parameter fields in `TSubmodDiff2DRootsNitrate.createAll`
- register the derived TVar fields so the 2D nitrate diffusion submodel exposes its grid metadata and uptake variables

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67c3d279083258b3e1a49a0add54d