### PR TITLE
Refactor root diffusion initialization helpers

### DIFF
--- a/Components/Soil/SubmodRootDiff1DRapp.pas
+++ b/Components/Soil/SubmodRootDiff1DRapp.pas
@@ -277,13 +277,9 @@ begin
     // ini-Methode inppar kann nur mit hexagonaler Verteilung verwendet werden:
     RootDistribution.Option := 'regular';
     // Gilt auch für Kennzahlen der Flächenverteilung
-    if RootDistribution.Option = 'regular' then
-      num_Roots.V := RLD_mean.V * dimensionX.V * dimensiony.V;
   end;
-  if RootDistribution.Option = 'regular' then
-  begin
-    CalcEqualDistribution;
-  end;
+
+  ApplyParameterRootInitialization;
 
   if (RootDistribution.Option <> 'regular') or (iniMethod.Option = 'xyfile')
   then

--- a/Components/Soil/SubmodRootDiff1DSolo.pas
+++ b/Components/Soil/SubmodRootDiff1DSolo.pas
@@ -480,18 +480,15 @@ begin
 
     if RootDistribution.Option = 'regular' then
       VarKoeff_RLD.V := 0;
-    num_Roots.V := RLD_mean.V * dimensionX.V * dimensionY.V;
   end;
+
+  ApplyParameterRootInitialization;
   // Initializations independent of the imported root data
   if integrationMethod.Option = 'numeric' then // only for numerical solution
   begin
     transform_Clmin;
   end;
   // In the case of a uniform distribution the PosArr must first be calculated.
-  if RootDistribution.Option = 'regular' then
-  begin
-    CalcEqualDistribution;
-  end;
   if RootDistribution.Option = 'random' then
   begin
     { Because the submodels have independent RasterData objects, a model comparison
@@ -1186,7 +1183,7 @@ end;
 
 procedure Register;
 (* -----------------------------------------------------------------------------
-  Prozedur wird für Komponenten benötigt: Registrierung der Komponenten auf einer
+  Prozedur wird fÃ¼r Komponenten benÃ¶tigt: Registrierung der Komponenten auf einer
   Palette.
   ------------------------------------------------------------------------------ *)
 begin

--- a/Components/Soil/USubmodRoot2DDiffNitrate.pas
+++ b/Components/Soil/USubmodRoot2DDiffNitrate.pas
@@ -121,6 +121,12 @@ type
     /// <summary>switch for growth in pots</summary>
     ContGrowth : TOption;
 
+    /// <summary>
+    /// Helper to apply shared initialization logic for parameter-based
+    /// configurations in derived classes.
+    /// </summary>
+    procedure ApplyParameterRootInitialization; virtual;
+
   public
     /// <summary>Public declarations</summary>
     /// <summary>Flag for one-time write access</summary>
@@ -429,6 +435,19 @@ begin
     have already been read. The original TSubmodel method cannot be used because it
     is called multiple times. }
 
+end;
+
+procedure TSubmodRoot2DDiffNitrate.ApplyParameterRootInitialization;
+begin
+  if iniMethod.Option = 'inppar' then
+  begin
+    RLD_mean.V := ParMRLD.V;
+    if RootDistribution.Option = 'regular' then
+      num_roots.V := RLD_mean.V * dimensionX.V * dimensionY.V;
+  end;
+
+  if RootDistribution.Option = 'regular' then
+    CalcEqualDistribution;
 end;
 
 


### PR DESCRIPTION
## Summary
- add a shared helper in `TSubmodRoot2DDiffNitrate` to encapsulate parameter-driven initialization
- call the helper from the 1D solo and Rapp diffusion submodels to remove duplicated setup code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8dfc62b148325a48b3847d6c85550